### PR TITLE
feat: remove console logging

### DIFF
--- a/v3/data/inject/page-blocker.js
+++ b/v3/data/inject/page-blocker.js
@@ -5,7 +5,6 @@ const validate = () => chrome.storage.local.get({
   map: {},
   notes: {}
 }, prefs => {
-  console.log(prefs);
   if (prefs.blocked.length) {
     chrome.runtime.sendMessage({
       method: 'convert',
@@ -14,7 +13,7 @@ const validate = () => chrome.storage.local.get({
       for (const {expression, host} of rules) {
         try {
           const r = new RegExp(expression, 'i');
-          console.log(r, expression);
+
           if (r.test(location.href)) {
             // make sure the rule does not match schedule
             return chrome.runtime.sendMessage({


### PR DESCRIPTION
This was added in 74dbe3b (likely for debugging) but it means all the preferences and rules get written to the console along with any other output from the website.

When developing other projects locally, this can cause the console to be a little noisy.

This change:
* Removes the console logging
