### PR TITLE
Fix blocking not resuming from pause if browser shutdown

### DIFF
--- a/v3/contextmenu.js
+++ b/v3/contextmenu.js
@@ -107,6 +107,7 @@ chrome.storage.onChanged.addListener(ps => {
 });
 
 const resume = () => {
+  chrome.storage.local.remove('pause-until');
   chrome.declarativeNetRequest.updateDynamicRules({
     removeRuleIds: [999]
   });
@@ -133,6 +134,7 @@ chrome.contextMenus.onClicked.addListener(async (info, tab) => {
           chrome.alarms.create('release.pause', {
             when
           });
+          chrome.storage.local.set({'pause-until': when});
         }
         const condition = {
           'resourceTypes': ['main_frame', 'sub_frame']
@@ -199,3 +201,10 @@ chrome.alarms.onAlarm.addListener(alarm => {
     resume();
   }
 });
+
+const tryResume = async () => {
+  const {['pause-until']: pauseUntil} = await storage({'pause-until': 0});
+  if (pauseUntil && Date.now() >= pauseUntil) {
+    resume();
+  }
+};

--- a/v3/worker.js
+++ b/v3/worker.js
@@ -278,6 +278,9 @@ chrome.runtime.onMessage.addListener((request, sender, response) => {
   }
 });
 
+/* resume blocking if pause expired while browser was closed */
+tryResume();
+
 /* update prefs from the managed storage */
 once(() => chrome.storage.managed.get({
   json: ''


### PR DESCRIPTION
So I've been running into an issue, where I pause the blocking for 5 minutes, and then the blocking never resumes. Most of the time it does resume, but sometimes not, and I think the cause is that the browser shutdown before resume was triggered.

I added a `pause-until` entry to local storage, which is checked whenever the `worker` runs and resumes if the pause time has expired.