### PR TITLE
Fix locale detection in getRelativeTime and minute pluralization in the pause menu

### DIFF
--- a/v3/contextmenu.js
+++ b/v3/contextmenu.js
@@ -30,7 +30,7 @@ const buildContext = () => chrome.storage.local.get({
     if (minutes) {
       s.push(
         minutes + ' ' +
-        translate(read.plural.select(hours) === 'one' ? 'bg_msg_23' : 'bg_msg_24')
+        translate(read.plural.select(minutes) === 'one' ? 'bg_msg_23' : 'bg_msg_24')
       );
     }
 
@@ -149,7 +149,6 @@ chrome.contextMenus.onClicked.addListener(async (info, tab) => {
           chrome.alarms.create('release.pause', {
             when
           });
-          console.log(when);
           // this is useful to know after a restart if we should remove the pause state or not
           chrome.storage.local.set({'pause-until': when});
         }

--- a/v3/utils.js
+++ b/v3/utils.js
@@ -7,7 +7,7 @@ function getRelativeTime(date) {
   const timeDifferenceInMonths = Math.floor(timeDifferenceInDays / 30);
   const timeDifferenceInYears = Math.floor(timeDifferenceInMonths / 12);
 
-  const rtf = new Intl.RelativeTimeFormat(navigator.locale, {numeric: 'auto'});
+  const rtf = new Intl.RelativeTimeFormat(navigator.language, {numeric: 'auto'});
 
   if (timeDifferenceInSeconds < 60) {
     return rtf.format(-timeDifferenceInSeconds, 'second');


### PR DESCRIPTION
Two small localization bugs:

**`v3/utils.js`** — `Intl.RelativeTimeFormat` was constructed with `navigator.locale`, which does not exist (always `undefined`), so the relative dates on the blocked page and in the options rule list silently fell back to the runtime default locale instead of the browser language. Use `navigator.language`.

**`v3/contextmenu.js`** — the minute part of the pause-menu labels selected its plural form from the **hour** count (`read.plural.select(hours)`), so e.g. a 121-minute period rendered as *"2 hours 1 minutes"*. Select from the minute count instead. Also removes a leftover debug `console.log(when)` in the pause handler.

### Testing
- Verified with a Node harness that loads the unmodified extension sources against a mocked `chrome.*` API:
  - `getRelativeTime(1h ago)` with `navigator.language = 'fr-FR'` now returns `il y a 1 heure`; before, it returned the OS locale formatting.
  - Pause-menu titles for periods `[121, 61, 5]` now select `bg_msg_23` (singular *minute*) / `bg_msg_24` (plural *minutes*) correctly: `121 → "2 hours 1 minute"`; on master the same test yields the wrong plural id.
- `eslint` (repo config) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)