### PR TITLE
Recompute schedules instead of re-phasing outdated schedule alarms

### DIFF
--- a/v3/idle.js
+++ b/v3/idle.js
@@ -1,16 +1,29 @@
 /* make sure timers are synced */
 
+/* global schedule */
+
 {
   const validate = async () => {
     const now = Date.now();
+    let reschedule = false;
     for (const o of await chrome.alarms.getAll()) {
       if (o.scheduledTime < now) {
         console.info('outdated timer', o);
-        chrome.alarms.create(o.name, {
-          when: now + Math.round(Math.random() * 1000),
-          periodInMinutes: o.periodInMinutes
-        });
+        // recreating a periodic "schedule.*" alarm with "when: now" permanently
+        // shifts its weekly phase to the wake-up time; recompute them instead
+        if (o.name.startsWith('schedule.')) {
+          reschedule = true;
+        }
+        else {
+          chrome.alarms.create(o.name, {
+            when: now + Math.round(Math.random() * 1000),
+            periodInMinutes: o.periodInMinutes
+          });
+        }
       }
+    }
+    if (reschedule) {
+      schedule.update();
     }
   };
 


### PR DESCRIPTION
`v3/idle.js` re-creates alarms that were missed while the machine was asleep with `when: now` **while keeping their `periodInMinutes`**. For the weekly `schedule.start.*` / `schedule.end.*` alarms this permanently shifts the schedule to the wake-up moment: a "Mon 9:00" schedule missed during sleep becomes a "Mon 10:23" schedule from then on, and the drift accumulates with every missed firing.

This patch keeps the old recreate behavior for regular alarms (`release.pause`, `release.open.once`), but when an outdated `schedule.*` alarm is found it calls `schedule.update()` once instead. That recreates all schedule alarms at their configured wall-clock times, and a currently-active window is still applied immediately (its start alarm is created with a past `when`, so it fires right away).

This may be one of the causes behind the schedule reliability reports in #116, #133 and #163 (schedules behaving differently after sleep/restart than right after saving).

Note: `idle.js` now references the `schedule` global; `schedule.js` is already loaded before `idle.js` in both the `importScripts` order (`worker.js`) and the Firefox `background.scripts` array, so no manifest change is needed.

### Testing
- Node harness loading the unmodified `idle.js` against a mocked `chrome.alarms`: with an outdated `schedule.start.*` alarm plus an outdated `release.pause` alarm, the patched version calls `schedule.update()` exactly once, does **not** re-create the schedule alarm with a shifted phase, and still re-creates `release.pause`. On master, the same test shows the schedule alarm being re-created at the wake-up time.
- `eslint` (repo config) passes.
- **Firefox**: verified the Firefox-only load path (`validate()` runs immediately at event-page load) with the same harness under a Firefox UA — an outdated `schedule.*` alarm triggers one `schedule.update()` and is not re-created with a shifted phase. `web-ext lint`: 0 errors, same 3 pre-existing manifest warnings as master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
