### PR TITLE
Replace the rule set atomically and fix tab-reload edge cases in update()

### DIFF
--- a/v3/blocker.js
+++ b/v3/blocker.js
@@ -3,13 +3,25 @@
 /* update rules */
 const update = async () => {
   if (update.busy) {
+    update.dirty = true;
     return new Promise((resolve, reject) => update.caches.add({resolve, reject}));
   }
   update.busy = true;
 
   const cc = e => {
     update.busy = false;
-    for (const {resolve, reject} of update.caches) {
+    const waiters = [...update.caches];
+    update.caches.clear();
+    // preferences changed while this run was in progress; re-run with fresh values
+    if (update.dirty) {
+      update.dirty = false;
+      update().then(
+        () => waiters.forEach(({resolve}) => resolve()),
+        e => waiters.forEach(({reject}) => reject(e))
+      );
+      return;
+    }
+    for (const {resolve, reject} of waiters) {
       if (e) {
         reject(e);
       }
@@ -17,7 +29,6 @@ const update = async () => {
         resolve();
       }
     }
-    update.caches.clear();
   };
 
   try {
@@ -34,12 +45,7 @@ const update = async () => {
       'pause-until': ''
     });
 
-    // remove old rules
     const rules = await chrome.declarativeNetRequest.getDynamicRules();
-    await chrome.declarativeNetRequest.updateDynamicRules({
-      removeRuleIds: rules.filter(r => r.id < 998).map(r => r.id)
-    });
-    const ids = [];
 
     const genRedirect = (address, date, host) => {
       if (address && /\\\d/.test(address)) {
@@ -66,48 +72,36 @@ const update = async () => {
       };
     };
 
-    // add new rules
+    // build the new rule set
+    const entries = []; // {host, rule}
     if (prefs.reverse) {
-      ids.push(1);
-      const rule = {
-        id: 1,
-        action: {
-          type: 'redirect',
-          redirect: genRedirect(prefs.redirect)
-        },
-        condition: {
-          regexFilter: '^http.*',
-          resourceTypes: prefs.contexts,
-          isUrlFilterCaseSensitive: false
+      entries.push({
+        host: '',
+        rule: {
+          id: 1,
+          action: {
+            type: 'redirect',
+            redirect: genRedirect(prefs.redirect)
+          },
+          condition: {
+            regexFilter: '^http.*',
+            resourceTypes: prefs.contexts,
+            isUrlFilterCaseSensitive: false
+          }
         }
-      };
-      await chrome.declarativeNetRequest.updateDynamicRules({
-        addRules: [rule]
       });
     }
     const hs = prefs.blocked.filter((s, i, l) => s && l.indexOf(s) === i);
     if (hs.length > prefs['max-number-of-rules']) {
-      notify(`You have too many blocking rules! Only the first 500 rules are applied.
+      notify(`You have too many blocking rules! Only the first ${prefs['max-number-of-rules']} rules are applied.
 
   Please merge them to keep the list less than ${prefs['max-number-of-rules']} items.`);
     }
 
     const hss = hs.slice(0, prefs['max-number-of-rules']);
-    let n = 0;
+    let id = prefs.reverse ? 1 : 0;
     for (const h of hss) {
-      // visual indicator
-      n += 1;
-      chrome.action.setBadgeText({text: (n / hss.length * 100).toFixed(0) + '%'});
-
-      // find a free id
-      let id;
-      for (let n = 1; ; n += 1) {
-        if (ids.indexOf(n) === -1) {
-          id = n;
-          ids.push(id);
-          break;
-        }
-      }
+      id += 1;
       // construct rule
       const rule = {
         id,
@@ -148,17 +142,52 @@ const update = async () => {
           });
         }
       }
+      entries.push({host: h, rule});
+    }
 
-      try {
-        await chrome.declarativeNetRequest.updateDynamicRules({
-          addRules: [rule]
-        });
+    // drop rules the engine cannot handle (e.g. invalid or too-complex regex)
+    if (chrome.declarativeNetRequest.isRegexSupported) {
+      const checks = await Promise.all(entries.map(({rule}) => chrome.declarativeNetRequest.isRegexSupported({
+        regex: rule.condition.regexFilter,
+        isCaseSensitive: false
+      })));
+      for (let n = entries.length - 1; n >= 0; n -= 1) {
+        if (checks[n].isSupported === false) {
+          console.warn('unsupported rule', entries[n].host, checks[n].reason);
+          notify(`cannot add rule "${entries[n].host}"
+
+  Error: ` + checks[n].reason);
+          entries.splice(n, 1);
+        }
       }
-      catch (e) {
-        console.warn(e);
-        notify(`cannot add rule "${h}"
+    }
+
+    // replace old rules with the new set in one atomic call so that there is
+    // no window where nothing is blocked and no partial set on failure
+    const removeRuleIds = rules.filter(r => r.id < 998).map(r => r.id);
+    try {
+      await chrome.declarativeNetRequest.updateDynamicRules({
+        removeRuleIds,
+        addRules: entries.map(o => o.rule)
+      });
+    }
+    catch (e) {
+      // e.g. the global regex memory limit; retry rule by rule so that one
+      // oversized rule does not take down the entire list
+      console.warn('batch rule update failed; retrying rule by rule', e);
+      await chrome.declarativeNetRequest.updateDynamicRules({removeRuleIds});
+      for (const {host, rule} of entries) {
+        try {
+          await chrome.declarativeNetRequest.updateDynamicRules({
+            addRules: [rule]
+          });
+        }
+        catch (e) {
+          console.warn(e);
+          notify(`cannot add rule "${host}"
 
   Error: ` + e.message);
+        }
       }
     }
     chrome.action.setBadgeText({text: ''});
@@ -173,12 +202,13 @@ const update = async () => {
     const tabs = prefs.initialBlock === false && prefs.initialBlockCurrent === false ?
       [] : await chrome.tabs.query(options);
 
+    const current = await chrome.declarativeNetRequest.getDynamicRules();
     // get schedule rules
-    const scheduleRegExp = (await chrome.declarativeNetRequest.getDynamicRules())
+    const scheduleRegExps = current
       .filter(r => r.id > 999)
       .map(r => new RegExp(r.condition.regexFilter, 'i'));
 
-    const regExps = (await chrome.declarativeNetRequest.getDynamicRules()).filter(r => {
+    const regExps = current.filter(r => {
       if (prefs.reverse && r.id === 1) {
         return false;
       }
@@ -186,24 +216,20 @@ const update = async () => {
     }).map(r => new RegExp(r.condition.regexFilter, 'i'));
 
     for (const tab of tabs) {
-      if (tab.url) {
-        for (const r of scheduleRegExp) {
-          if (r.test(tab.url)) {
-            continue;
-          }
+      if (!tab.url) {
+        continue;
+      }
+      // the tab is currently allowed by an active schedule rule
+      if (scheduleRegExps.some(r => r.test(tab.url))) {
+        continue;
+      }
+      if (prefs.reverse) {
+        if (regExps.some(r => r.test(tab.url)) === false) {
+          chrome.tabs.reload(tab.id);
         }
-        if (prefs.reverse) {
-          if (regExps.some(r => r.test(tab.url)) === false) {
-            chrome.tabs.reload(tab.id);
-          }
-        }
-        else {
-          for (const r of regExps) {
-            if (r.test(tab.url)) {
-              chrome.tabs.reload(tab.id);
-            }
-          }
-        }
+      }
+      else if (regExps.some(r => r.test(tab.url))) {
+        chrome.tabs.reload(tab.id);
       }
     }
     // Evaluate the address on the active blocked page


### PR DESCRIPTION
### Rule updates: one atomic call instead of remove-then-add-one-by-one

`update()` used to remove all rules first and then re-add them **one `updateDynamicRules` call per rule**. Consequences:

- a time window on every preference change (and every browser start) where **nothing is blocked**;
- if the service worker is killed mid-loop, a **partial rule set** remains;
- 500 sequential API calls (default `max-number-of-rules`) on every save.

The patch builds the complete rule set first and swaps it in with a single `updateDynamicRules({removeRuleIds, addRules})` call, which the API applies atomically. Per-rule error reporting is preserved:

- regexes are pre-validated with `declarativeNetRequest.isRegexSupported()` (feature-detected, available in both Chrome and Firefox) — unsupported rules are reported via the existing notification and skipped;
- if the batch call itself is rejected (e.g. the global regex memory limit), it falls back to the previous rule-by-rule path so one oversized rule cannot take down the entire list.

The per-rule badge progress indicator becomes obsolete and is removed; the too-many-rules notification now reports the configured `max-number-of-rules` value instead of a hard-coded "500".

### update() coalescing

When preferences changed while a run was in progress, the queued call piggybacked on the in-flight run and its new values were **never applied** — the rule set stayed stale until the next unrelated change. A dirty flag now triggers exactly one re-run with fresh preferences.

### Tab reload pass

- The schedule check used `continue` inside the inner regex loop — a no-op — so tabs that are currently allowed by an active schedule rule were reloaded anyway. They are now skipped properly.
- A tab matching several blocking rules was reloaded once per match; it now reloads at most once.
- One `getDynamicRules()` snapshot is reused instead of querying twice.

### Testing

- **Unit** (Node harness loading `helper.js` + `worker.js` + `blocker.js` against a mocked `chrome.*` API, mock enforces `updateDynamicRules` atomicity and unique rule ids): normal mode, reverse mode, `map` redirects (`close` / custom URL / blocked-page with `date`/`host` params), unsupported-regex skip, batch-failure fallback, stale-pause resume, dirty re-run, schedule-tab skip, single reload. All pass on this branch; on master the same suite reproduces the stale-prefs bug and the schedule-tab reload bug.
- **End-to-end** (Chrome for Testing 149, `--load-extension`, via puppeteer): rules install as a single batch; navigating to a blocked host lands on the blocked page with correct `host`/`url=\0` parameters; a custom redirect map is applied (verified through a redirect chain onto another blocked host); the options page lists the rules without errors; reverse (whitelist) mode blocks non-listed hosts.
- `eslint` (repo config) passes.
- **Firefox**: `declarativeNetRequest.isRegexSupported`/`updateDynamicRules`/`MAX_NUMBER_OF_REGEX_RULES` are all available since Firefox 113 (< `strict_min_version` 128, checked against @mdn/browser-compat-data), and `isRegexSupported` stays feature-detected anyway. The full unit suite also passes when loaded in the Firefox event-page script order from `manifest-firefox.json` (`blocker.js` before `worker.js`, `browser` global, Firefox UA). End-to-end on Firefox 152 (temporary install via WebDriver BiDi): adding a rule through the options UI installs the batch-built rules and navigating to the blocked host lands on the blocked page with the full address carried via `\0`. `web-ext lint`: 0 errors, same 3 pre-existing manifest warnings as master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
