### PR TITLE
Validate preferences file before importing

### DIFF
--- a/v3/data/options/index.js
+++ b/v3/data/options/index.js
@@ -492,12 +492,24 @@ document.addEventListener('click', e => {
           const reader = new FileReader();
           reader.onloadend = event => {
             input.remove();
-            const json = JSON.parse(event.target.result);
-            chrome.storage.local.clear(() => chrome.storage.local.set(json, () => {
-              window.removeEventListener('beforeunload', warning);
-              chrome.runtime.reload();
-              window.close();
-            }));
+            // validate before wiping the current preferences
+            try {
+              const json = JSON.parse(event.target.result);
+              if (!json || typeof json !== 'object' || Array.isArray(json)) {
+                throw Error('This file does not contain a preferences object');
+              }
+              if (Object.keys(json).some(key => key in DEFAULTS) === false) {
+                throw Error('No known preferences found in this file');
+              }
+              chrome.storage.local.clear(() => chrome.storage.local.set(json, () => {
+                window.removeEventListener('beforeunload', warning);
+                chrome.runtime.reload();
+                window.close();
+              }));
+            }
+            catch (e) {
+              toast('Import failed: ' + e.message, 4000, 'error');
+            }
           };
           reader.readAsText(file, 'utf-8');
         }


### PR DESCRIPTION
In the options page, "import json" ran `JSON.parse` without a try/catch, so a malformed file failed silently with an uncaught exception. Worse, any syntactically valid JSON — an array, a plain string, an unrelated object — wiped all existing preferences via `storage.local.clear()` and was then written verbatim.

The patch parses and sanity-checks the file first: it must be an object carrying at least one known preference key (checked against the existing `DEFAULTS` map). Failures surface as an error toast, and the current preferences are only cleared once the file looks like an actual backup.

### Testing
- End-to-end (Chrome for Testing 149, `--load-extension`, via puppeteer): the options page loads without errors; evaluated the guard in the live page — it accepts the repository's own `examples/block-site-preferences.json` and rejects an array, a string and a foreign object.
- `eslint` (repo config) passes.
- **Firefox**: end-to-end on Firefox 152 (temporary install via WebDriver BiDi) — the options page loads without uncaught errors and the guard accepts the repository's example backup while rejecting non-backup JSON. `web-ext lint`: 0 errors, same 3 pre-existing manifest warnings as master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
