### PR TITLE
Treat a 23:59 schedule end time as end-of-day

### DIFF
--- a/v3/schedule.js
+++ b/v3/schedule.js
@@ -54,6 +54,11 @@ const schedule = {
           end.setSeconds(0);
           end.setMinutes(Number(em));
           end.setHours(Number(eh));
+          // "23:59" is the highest value the time input accepts; treat it as
+          // end-of-day so the last minute of the day is not left out
+          if (Number(eh) === 23 && Number(em) === 59) {
+            end.setHours(24, 0, 0);
+          }
 
           if (start.getTime() < now && end.getTime() < now) {
             start.setDate(start.getDate() + 7);


### PR DESCRIPTION
Fixes #127.

`23:59` is the highest value the HTML time input accepts, so the last minute of the day could never be part of a schedule window: the helper-generated unblocking periods (e.g. `17:00–23:59`) silently re-blocked everything from 23:59:00 until midnight, and there was no way to express "until end of day".

This patch interprets an end time of `23:59` in `schedule.js` as 00:00 of the following day. A `00:00–23:59` entry consequently covers the entire day. Ordinary end times are unaffected, and no UI or storage-format change is needed — existing helper-generated schedules start behaving as intended.

### Testing
- Node harness loading the unmodified `helper.js` + `schedule.js` against a mocked `chrome.*` API: for a `17:00–23:59` window the end alarm now fires at midnight (a full 7-hour window, previously 6 h 59 min); `00:00–23:59` spans 24 h; a `09:00–17:30` window is byte-identical to master behavior. The master branch fails the two end-of-day cases and passes the third.
- `eslint` (repo config) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)