### PR TITLE
Make the master password optional for temporary unlocks

### DIFF
--- a/v3/_locales/de/messages.json
+++ b/v3/_locales/de/messages.json
@@ -170,6 +170,9 @@
   "options_no_pass_on_add": {
     "message": "Nicht nach dem Hauptasswort fragen, um einen neuen Hostnamen zu blockieren"
   },
+  "options_no_pass_on_unlock": {
+    "message": "Nicht nach dem Hauptpasswort fragen, um eine gesperrte Seite vorübergehend freizugeben"
+  },
   "options_disable_actions_options": {
     "message": "Kontextmenü auf dieser Seite blockieren"
   },

--- a/v3/_locales/en/messages.json
+++ b/v3/_locales/en/messages.json
@@ -170,6 +170,9 @@
   "options_no_pass_on_add": {
     "message": "Do not ask for the master password to block a new hostname"
   },
+  "options_no_pass_on_unlock": {
+    "message": "Do not ask for the master password to temporarily unlock a blocked page"
+  },
   "options_disable_actions_options": {
     "message": "Block context menu on this page"
   },

--- a/v3/data/blocked/index.js
+++ b/v3/data/blocked/index.js
@@ -160,6 +160,7 @@ Promise.all([
     css: '',
     password: '',
     sha256: '',
+    'no-password-on-unlock': false,
     reverse: false,
     blocked: [],
     notes: {}
@@ -172,6 +173,19 @@ Promise.all([
 ]).then(a => a[1]).then(prefs => {
   if (prefs.title && href) {
     title();
+  }
+  // the master password is optional (https://github.com/ray-lothian/Block-Site/issues/42).
+  const hasPassword = prefs.password || prefs.sha256;
+  const unlockNeedsPassword = hasPassword && !prefs['no-password-on-unlock'];
+  // don't force a password on the unlock form when it isn't required...
+  if (!unlockNeedsPassword) {
+    password.required = false;
+  }
+  // ...but only fully hide the field when there is no password at all. If a
+  // password exists it is still needed by the "remove blocking" button below,
+  // so keep it visible even when unlocking itself is password-free.
+  if (!hasPassword) {
+    password.hidden = true;
   }
   if (args.has('host')) {
     const h = args.get('host');

--- a/v3/data/options/index.html
+++ b/v3/data/options/index.html
@@ -157,6 +157,10 @@
       <label for="no-password-on-add"><span data-i18n="options_no_pass_on_add"></span></label>
     </div>
     <div hbox class="space" align="center">
+      <input type="checkbox" id="no-password-on-unlock">&nbsp;
+      <label for="no-password-on-unlock"><span data-i18n="options_no_pass_on_unlock"></span></label>
+    </div>
+    <div hbox class="space" align="center">
       <input type="checkbox" id="disable-actions-options">&nbsp;
       <label for="disable-actions-options"><span data-i18n="options_disable_actions_options"></span></label>
     </div>

--- a/v3/data/options/index.js
+++ b/v3/data/options/index.js
@@ -42,6 +42,7 @@ const DEFAULTS = {
   'title': true,
   'reverse': false,
   'no-password-on-add': false,
+  'no-password-on-unlock': false,
   'map': {},
   'schedule': {
     time: { // deprecated
@@ -258,6 +259,7 @@ const init = (table = true) => chrome.storage.local.get(DEFAULTS, ps => {
   document.getElementById('schedule-offset').dispatchEvent(new Event('input'));
   document.getElementById('reverse').checked = prefs.reverse;
   document.getElementById('no-password-on-add').checked = prefs['no-password-on-add'];
+  document.getElementById('no-password-on-unlock').checked = prefs['no-password-on-unlock'];
   document.getElementById('timeout').value = prefs.timeout;
   document.getElementById('unlock-periods').value = prefs['unlock-periods'].join(', ');
   rebuildUnlockDefault(String(prefs['unlock-default']));
@@ -422,6 +424,7 @@ document.addEventListener('click', e => {
         'schedule-offset': Number(document.getElementById('schedule-offset').value),
         'reverse': document.getElementById('reverse').checked,
         'no-password-on-add': document.getElementById('no-password-on-add').checked,
+        'no-password-on-unlock': document.getElementById('no-password-on-unlock').checked,
         'redirect': document.getElementById('redirect').value,
         'message': document.getElementById('message').value,
         'css': document.getElementById('css').value,

--- a/v3/worker.js
+++ b/v3/worker.js
@@ -321,6 +321,7 @@ chrome.runtime.onMessage.addListener((request, sender, response) => {
   else if (request.method === 'open-once') {
     chrome.storage.local.get({
       'timeout': 60, // seconds; default unlock duration
+      'no-password-on-unlock': false,
       'sha256': '', // sha256 hash code of the user password
       'password': '' // deprecated
     }).then(prefs => {
@@ -340,9 +341,10 @@ chrome.runtime.onMessage.addListener((request, sender, response) => {
         }
       };
 
-      if (prefs.password === '' && prefs.sha256 === '') {
-        response(false);
-        notify(translate('bg_msg_3'));
+      // the master password is optional: unlock straight away when none is
+      // set, or when the user opted out of the unlock prompt
+      if ((prefs.password === '' && prefs.sha256 === '') || prefs['no-password-on-unlock']) {
+        next();
       }
       else {
         sha256.validate(request, next, msg => {


### PR DESCRIPTION
Split out of #172 as requested — this part only makes the master password optional for unlocking.

Two cases (asked for in #42 and #70):

- **No master password configured:** the blocked page no longer rejects the unlock with “set a password first” — it simply unlocks, and the unused password field is hidden.
- **A password exists, but the user opts out** via the new *“Do not ask for the master password to temporarily unlock a blocked page”* option (mirroring the existing `no-password-on-add`): the field stays visible — the remove-blocking link still requires it — but is no longer required for unlocking.

Blocking-list changes (add/remove) keep their existing password protection; only the temporary unlock is affected.

### Testing
- Node unit suite over a `declarativeNetRequest` mock: no password ⇒ unlock proceeds; password + opt-out ⇒ unlock without prompt; password required ⇒ wrong/empty password refused, correct password unlocks. All pass.
- `web-ext lint`: 0 errors; en+de locales included.

Closes #70 (refs #42).

Independent of the other split PRs; it touches the same open-once handler as the unlock-durations PR (#173) — the conflict is a few lines, happy to rebase whichever lands later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)