### PR TITLE
Add an optional per-site note, shown and editable on the blocked page

### DIFF
--- a/v3/_locales/de/messages.json
+++ b/v3/_locales/de/messages.json
@@ -12,7 +12,7 @@
     "message": "Weiterleiten nach:"
   },
   "options_user_message": {
-    "message": "Benutzernachricht:"
+    "message": "Benutzernachricht (wird auf jeder Sperrseite angezeigt – für einen Hinweis pro Seite die Notiz verwenden):"
   },
   "options_custom_css": {
     "message": "Angepasstes CSS:"
@@ -76,6 +76,9 @@
   },
   "options_remove": {
     "message": "Entfernen"
+  },
+  "options_note": {
+    "message": "Notiz für die Sperrseite (optional)"
   },
   "options_rate": {
     "message": "Bewerten Sie uns"
@@ -280,6 +283,12 @@
   },
   "blocked_counter": {
     "message": "Anzahl Blockierungen"
+  },
+  "blocked_note": {
+    "message": "Notiz"
+  },
+  "blocked_note_ph": {
+    "message": "Notiz für diese Seite hinzufügen …"
   },
   "blocked_master_password": {
     "message": "Bitte Hauptpasswort eingeben und dann die Eingabetaste drücken, um die Blockade zu unterbrechen."

--- a/v3/_locales/en/messages.json
+++ b/v3/_locales/en/messages.json
@@ -12,7 +12,7 @@
     "message": "Redirect to:"
   },
   "options_user_message": {
-    "message": "User message:"
+    "message": "User message (shown on every blocked page — for a per-site reminder use the note instead):"
   },
   "options_custom_css": {
     "message": "Custom CSS:"
@@ -76,6 +76,9 @@
   },
   "options_remove": {
     "message": "Remove"
+  },
+  "options_note": {
+    "message": "Note shown on the blocked page (optional)"
   },
   "options_rate": {
     "message": "Rate Me"
@@ -280,6 +283,12 @@
   },
   "blocked_rule_ph": {
     "message": "Blocking rule (edit to change the scope)"
+  },
+  "blocked_note": {
+    "message": "Note"
+  },
+  "blocked_note_ph": {
+    "message": "Add a note for this site…"
   },
   "blocked_master_password": {
     "message": "Enter the master password, then press enter to unblock"

--- a/v3/data/blocked/index.css
+++ b/v3/data/blocked/index.css
@@ -34,6 +34,7 @@ html.dark body {
   background-blend-mode: luminosity;
 }
 
+#note,
 #rule {
   color: var(--input-fg);
   background-color: var(--input-bg);
@@ -45,6 +46,9 @@ html.dark body {
   box-sizing: border-box;
   width: 100%;
   max-width: 420px;
+}
+#note {
+  resize: vertical;
 }
 
 @media screen and (max-height: 400px) {

--- a/v3/data/blocked/index.html
+++ b/v3/data/blocked/index.html
@@ -28,6 +28,8 @@
       <span id="date"></span>
       <span data-i18n="blocked_counter"></span>
       <span id="counter"></span>
+      <span data-i18n="blocked_note" id="note-label" hidden></span>
+      <textarea id="note" rows="2" data-i18n="blocked_note_ph" data-i18n-value="placeholder" hidden></textarea>
     </div>
   </header>
   <p id="message"></p>

--- a/v3/data/blocked/index.js
+++ b/v3/data/blocked/index.js
@@ -205,6 +205,31 @@ Promise.all([
       });
     });
 
+    // editable per-site note (https://github.com/ray-lothian/Block-Site/issues/64):
+    // shown here and writable straight from the blocked page. It is keyed by
+    // the rule, so it follows a rename through "ruleKey"
+    const note = document.getElementById('note');
+    note.hidden = false;
+    document.getElementById('note-label').hidden = false;
+    note.value = o.note || '';
+    const saveNote = () => chrome.storage.local.get({notes: {}}, p => {
+      const entry = {...(p.notes[ruleKey] || o)};
+      const text = note.value.trim();
+      if (text) {
+        entry.note = text;
+      }
+      else {
+        delete entry.note;
+      }
+      chrome.storage.local.set({notes: {...p.notes, [ruleKey]: entry}});
+    });
+    let timer;
+    note.addEventListener('input', () => {
+      clearTimeout(timer);
+      timer = setTimeout(saveNote, 500);
+    });
+    note.addEventListener('change', saveNote);
+
     const count = (o.count || 0) + 1;
     document.getElementById('counter').textContent = count;
     chrome.storage.local.set({

--- a/v3/data/options/index.css
+++ b/v3/data/options/index.css
@@ -143,6 +143,15 @@ a:visited {
 #rules-container > div {
   display: contents;
 }
+#rules-container [data-id="note"] {
+  grid-column: 1 / -1;
+  margin-bottom: 8px;
+  opacity: 0.85;
+  font-size: 90%;
+}
+#rules-container [data-id="note"]:focus {
+  opacity: 1;
+}
 
 @media screen and (max-width: 550px) {
   #rules-container > div {

--- a/v3/data/options/index.html
+++ b/v3/data/options/index.html
@@ -33,9 +33,10 @@
     <template>
       <div>
         <span title="Click to insert the rule" data-id="href">HTTP://</span>
-        <input type="text" flex="1" placeholder="Optional redirect URL or 'close' keyword." title="Backslash-escaped digits (\1 to \9) can be used to insert the corresponding capture groups. Adding capture groups to the generated URL might cause it to match the blocking rule again, potentially leading to multiple redirects. Use caution.">
+        <input type="text" data-id="redirect" flex="1" placeholder="Optional redirect URL or 'close' keyword." title="Backslash-escaped digits (\1 to \9) can be used to insert the corresponding capture groups. Adding capture groups to the generated URL might cause it to match the blocking rule again, potentially leading to multiple redirects. Use caution.">
         <span data-id="date">-</span>
         <input type="button" data-cmd="remove">
+        <input type="text" data-id="note" class="note" data-i18n="options_note" data-i18n-value="placeholder">
       </div>
     </template>
     <div id="rules-container"></div>

--- a/v3/data/options/index.js
+++ b/v3/data/options/index.js
@@ -102,9 +102,10 @@ function add(hostname) {
     node.querySelector('[data-id=date]').textContent = getRelativeTime(d);
   }
 
-  const rd = node.querySelector('input');
+  const rd = node.querySelector('[data-id=redirect]');
   rd.value = prefs.map[hostname] || '';
   // rd.disabled = hostname.indexOf('*') !== -1;
+  node.querySelector('[data-id=note]').value = prefs.notes[hostname]?.note || '';
   node.querySelector('[data-cmd="remove"]').value = chrome.i18n.getMessage('options_remove');
   document.getElementById('rules-container').appendChild(node);
   list.dataset.visible = true;
@@ -436,12 +437,20 @@ document.addEventListener('click', e => {
           .map(tr => tr.dataset.hostname)
           .filter((s, i, l) => s && l.indexOf(s) === i),
         'notes': [...document.querySelectorAll('#rules-container > div')].reduce((p, c) => {
-          p[c.dataset.hostname] = JSON.parse(c.dataset.note);
+          const o = JSON.parse(c.dataset.note);
+          const note = c.querySelector('[data-id=note]').value.trim();
+          if (note) {
+            o.note = note;
+          }
+          else {
+            delete o.note;
+          }
+          p[c.dataset.hostname] = o;
           return p;
         }, {}),
         'map': [...document.querySelectorAll('#rules-container > div')].reduce((p, c) => {
           const {hostname} = c.dataset;
-          const mapped = c.querySelector('input[type=text]').value;
+          const mapped = c.querySelector('[data-id=redirect]').value;
           if (mapped) {
             p[hostname] = mapped;
           }


### PR DESCRIPTION
Split out of #172 as requested — this part only adds per-site notes (asked for in #64 and #63).

Each blocking rule can carry a short free-text note, stored as `notes[host].note` next to the existing date/count metadata. It can be written directly on the blocked page — a small textarea under “Blocked Count”, saved as you type — or in the options rule list, and is shown again whenever the page is blocked. Useful as a reminder of why a site was blocked (unlike the global “user message”, which is the same on every blocked page; its options label now points that out).

The redirect input in the options rule row gets an explicit `data-id="redirect"` so the row’s two text inputs stay unambiguous.

### Testing
- Exercised on real Firefox 152 and Chrome for Testing (write on the blocked page, reload, edit in the options, empty note removes the entry).
- `web-ext lint`: 0 errors; en+de locales included.

Refs #64, #63.

Independent of the other split PRs; if the popup overview (#176) lands too, it shows this note in small text under each host — the two compose without changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)