### PR TITLE
Add a toolbar popup listing the blocked sites, with one-click block/unblock

### DIFF
--- a/v3/_locales/de/messages.json
+++ b/v3/_locales/de/messages.json
@@ -194,6 +194,39 @@
   "options_contextmenu_periods": {
     "message": "Zeit anhalten (in Minuten)"
   },
+  "options_popup": {
+    "message": "Beim Klick auf das Symbol in der Symbolleiste eine Übersicht der gesperrten Seiten anzeigen (sonst sperrt ein Klick die aktuelle Seite)"
+  },
+  "popup_options": {
+    "message": "Einstellungen"
+  },
+  "popup_filter": {
+    "message": "Gesperrte Seiten filtern…"
+  },
+  "popup_empty": {
+    "message": "Noch keine gesperrten Seiten."
+  },
+  "popup_remove": {
+    "message": "Diese Regel entfernen"
+  },
+  "popup_no_site": {
+    "message": "Keine sperrbare Seite"
+  },
+  "popup_block": {
+    "message": "Diese URL sperren"
+  },
+  "popup_unblock": {
+    "message": "Diese URL freigeben"
+  },
+  "popup_toggle": {
+    "message": "Diese Seite (nicht mehr) sperren"
+  },
+  "popup_reverse_hint": {
+    "message": "Im Rückwärtsmodus standardmäßig gesperrt. Öffnen Sie die Seite und nutzen Sie „Zur Positivliste hinzufügen“, um sie freizugeben."
+  },
+  "popup_blocked_count": {
+    "message": "## × gesperrt"
+  },
   "options_incognito": {
     "message": "Die Einstellungsseite ist im Inkognitokontext nicht verfügbar"
   },
@@ -214,6 +247,12 @@
   },
   "blocked_since": {
     "message": "Blockiert seit"
+  },
+  "blocked_rule": {
+    "message": "Regel"
+  },
+  "blocked_rule_ph": {
+    "message": "Sperr-Regel (bearbeiten, um den Umfang zu ändern)"
   },
   "blocked_master_password": {
     "message": "Bitte Hauptpasswort eingeben und dann die Eingabetaste drücken, um die Blockade für eine Minute zu unterbrechen."

--- a/v3/_locales/en/messages.json
+++ b/v3/_locales/en/messages.json
@@ -173,6 +173,9 @@
   "options_notification": {
     "message": "Display desktop notifications (recommended)"
   },
+  "options_popup": {
+    "message": "Show an overview of blocked sites when clicking the toolbar icon (otherwise a click blocks the current site)"
+  },
   "options_contexts": {
     "message": "Choose where blocking applies"
   },
@@ -224,6 +227,36 @@
   "options_manual_pause": {
     "message": "Forever"
   },
+  "popup_options": {
+    "message": "Options"
+  },
+  "popup_filter": {
+    "message": "Filter blocked sites…"
+  },
+  "popup_empty": {
+    "message": "No blocked sites yet."
+  },
+  "popup_remove": {
+    "message": "Remove this rule"
+  },
+  "popup_no_site": {
+    "message": "No blockable site"
+  },
+  "popup_block": {
+    "message": "Block this URL"
+  },
+  "popup_unblock": {
+    "message": "Unblock this URL"
+  },
+  "popup_toggle": {
+    "message": "(Un)block this site"
+  },
+  "popup_reverse_hint": {
+    "message": "Blocked by default in reverse mode. Open the site and use \"Add to Whitelist\" to allow it."
+  },
+  "popup_blocked_count": {
+    "message": "blocked ##×"
+  },
   "blocked_restricted": {
     "message": "Restricted Access"
   },
@@ -235,6 +268,12 @@
   },
   "blocked_counter": {
     "message": "Blocked Count"
+  },
+  "blocked_rule": {
+    "message": "Rule"
+  },
+  "blocked_rule_ph": {
+    "message": "Blocking rule (edit to change the scope)"
   },
   "blocked_master_password": {
     "message": "Enter the master password, then press enter to unblock for a minute"

--- a/v3/data/blocked/index.css
+++ b/v3/data/blocked/index.css
@@ -34,6 +34,19 @@ html.dark body {
   background-blend-mode: luminosity;
 }
 
+#rule {
+  color: var(--input-fg);
+  background-color: var(--input-bg);
+  border: none;
+  outline: none;
+  padding: 8px;
+  font-family: inherit;
+  font-size: inherit;
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 420px;
+}
+
 @media screen and (max-height: 400px) {
   html.complete body {
     background-image: none !important;

--- a/v3/data/blocked/index.html
+++ b/v3/data/blocked/index.html
@@ -22,6 +22,8 @@
         <span id="pathname"></span>
         <span id="search"></span>
       </a>
+      <span data-i18n="blocked_rule" id="rule-label" hidden></span>
+      <input type="text" id="rule" data-i18n="blocked_rule_ph" data-i18n-value="placeholder" hidden>
       <span data-i18n="blocked_since"></span>
       <span id="date"></span>
       <span data-i18n="blocked_counter"></span>

--- a/v3/data/blocked/index.js
+++ b/v3/data/blocked/index.js
@@ -120,6 +120,35 @@ Promise.all([
   if (args.has('host')) {
     const h = args.get('host');
     const o = prefs.notes[h] || {};
+
+    // the rule that caught this page is editable here, so the block can be
+    // narrowed to this URL or widened to the whole site. Its metadata
+    // (date, blocked count) follows the renamed rule.
+    let ruleKey = h;
+    const ruleEl = document.getElementById('rule');
+    ruleEl.hidden = false;
+    document.getElementById('rule-label').hidden = false;
+    ruleEl.value = h;
+    ruleEl.addEventListener('change', () => {
+      const next = ruleEl.value.trim();
+      if (!next || next === ruleKey) {
+        return;
+      }
+      chrome.storage.local.get({blocked: [], notes: {}}, p => {
+        const blocked = p.blocked.filter(x => x !== ruleKey);
+        if (blocked.includes(next) === false) {
+          blocked.push(next);
+        }
+        const notes = {...p.notes};
+        if (notes[ruleKey]) {
+          notes[next] = notes[ruleKey];
+          delete notes[ruleKey];
+        }
+        ruleKey = next;
+        chrome.storage.local.set({blocked, notes, changed: Math.random()});
+      });
+    });
+
     const count = (o.count || 0) + 1;
     document.getElementById('counter').textContent = count;
     chrome.storage.local.set({

--- a/v3/data/options/index.html
+++ b/v3/data/options/index.html
@@ -168,6 +168,10 @@
       <input type="checkbox" id="notification">&nbsp;
       <label for="notification"><span data-i18n="options_notification"></span></label>
     </div>
+    <div hbox class="space" align="center">
+      <input type="checkbox" id="popup">&nbsp;
+      <label for="popup"><span data-i18n="options_popup"></span></label>
+    </div>
   </div>
   <div class="space view">
     <span data-i18n="options_contexts"></span>

--- a/v3/data/options/index.js
+++ b/v3/data/options/index.js
@@ -61,6 +61,7 @@ const DEFAULTS = {
   'disable-actions-options': true,
   'disable-actions-page': true,
   'notification': true,
+  'popup': true,
   'contexts': ['main_frame', 'sub_frame']
 };
 const prefs = {};
@@ -220,6 +221,7 @@ const init = (table = true) => chrome.storage.local.get(DEFAULTS, ps => {
   document.getElementById('disable-actions-options').checked = prefs['disable-actions-options'];
   document.getElementById('disable-actions-page').checked = prefs['disable-actions-page'];
   document.getElementById('notification').checked = prefs['notification'];
+  document.getElementById('popup').checked = prefs['popup'];
   document.getElementById('initialBlock').checked = prefs.initialBlock;
   document.getElementById('initialBlockCurrent').checked = prefs.initialBlockCurrent;
   document.getElementById('schedule-offset').value = prefs['schedule-offset'];
@@ -376,6 +378,7 @@ document.addEventListener('click', e => {
         'disable-actions-options': document.getElementById('disable-actions-options').checked,
         'disable-actions-page': document.getElementById('disable-actions-page').checked,
         'notification': document.getElementById('notification').checked,
+        'popup': document.getElementById('popup').checked,
         'schedule-offset': Number(document.getElementById('schedule-offset').value),
         'reverse': document.getElementById('reverse').checked,
         'no-password-on-add': document.getElementById('no-password-on-add').checked,

--- a/v3/data/popup/index.css
+++ b/v3/data/popup/index.css
@@ -1,23 +1,13 @@
 :root {
-  --bg: #fff;
-  --fg: #333;
-  --muted: #888;
-  --border: #ddd;
-  --hover: #f2f6f9;
-  --link: #07c;
-  --input-bg: #fff;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --bg: #202124;
-    --fg: #d0d0d0;
-    --muted: #8a8a8a;
-    --border: #3a3d42;
-    --hover: #2a2f3a;
-    --link: #6bb3e0;
-    --input-bg: #17181a;
-  }
+  color-scheme: light dark;
+  
+  --bg: light-dark(#fff, #202124);
+  --fg: light-dark(#333, #d0d0d0);
+  --muted: light-dark(#888, #8a8a8a);
+  --border: light-dark(#ddd, #3a3d42);
+  --hover: light-dark(#f2f6f9, #2a2f3a);
+  --link: light-dark(#07c, #6bb3e0);
+  --input-bg: light-dark(#fff, #17181a);
 }
 
 * {

--- a/v3/data/popup/index.css
+++ b/v3/data/popup/index.css
@@ -1,0 +1,144 @@
+:root {
+  --bg: #fff;
+  --fg: #333;
+  --muted: #888;
+  --border: #ddd;
+  --hover: #f2f6f9;
+  --link: #07c;
+  --input-bg: #fff;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #202124;
+    --fg: #d0d0d0;
+    --muted: #8a8a8a;
+    --border: #3a3d42;
+    --hover: #2a2f3a;
+    --link: #6bb3e0;
+    --input-bg: #17181a;
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+body {
+  width: 360px;
+  max-height: 560px;
+  margin: 0;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 13px;
+  color: var(--fg);
+  background: var(--bg);
+  display: flex;
+  flex-direction: column;
+}
+
+#current {
+  display: grid;
+  grid-template-columns: 1fr min-content min-content;
+  gap: 8px;
+  align-items: center;
+  padding: 10px;
+  border-bottom: solid 1px var(--border);
+}
+#host {
+  font-weight: bold;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+#toggle {
+  cursor: pointer;
+  white-space: nowrap;
+  padding: 5px 10px;
+  border: solid 1px var(--border);
+  background: var(--input-bg);
+  color: var(--fg);
+  border-radius: 3px;
+}
+/* blocking is the "destructive" direction: make it stand out in red */
+#toggle.block {
+  color: #d81a1a;
+  border-color: #d81a1a;
+}
+#toggle:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+#options {
+  text-decoration: none;
+  font-size: 18px;
+  line-height: 1;
+  color: var(--link);
+  padding: 2px 4px;
+}
+
+#filter {
+  margin: 8px 10px 4px;
+  padding: 6px 8px;
+  border: solid 1px var(--border);
+  border-radius: 3px;
+  background: var(--input-bg);
+  color: var(--fg);
+  outline: none;
+}
+
+#list {
+  overflow-y: auto;
+  padding: 0 4px 6px;
+}
+.row {
+  display: grid;
+  grid-template-columns: 1fr min-content;
+  gap: 8px;
+  align-items: center;
+  padding: 6px;
+  border-radius: 4px;
+}
+.row:hover {
+  background: var(--hover);
+}
+.info {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+.info .host {
+  font-weight: bold;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.info .note {
+  color: var(--muted);
+  font-size: 10px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.info .meta {
+  color: var(--muted);
+  font-size: 10px;
+}
+.remove {
+  cursor: pointer;
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  font-size: 13px;
+  padding: 4px 6px;
+  border-radius: 3px;
+}
+.remove:hover {
+  color: #c00;
+  background: var(--hover);
+}
+
+#empty {
+  padding: 20px 10px;
+  text-align: center;
+  color: var(--muted);
+}

--- a/v3/data/popup/index.html
+++ b/v3/data/popup/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="index.css">
+  <title>Block Site</title>
+</head>
+<body>
+  <div id="current">
+    <span id="host">…</span>
+    <input type="button" id="toggle" value="">
+    <a href="#" id="options" data-i18n="popup_options" data-i18n-value="title">⚙</a>
+  </div>
+  <input type="search" id="filter" data-i18n="popup_filter" data-i18n-value="placeholder">
+  <div id="list"></div>
+  <div id="empty" data-i18n="popup_empty" hidden></div>
+  <template id="row">
+    <div class="row">
+      <div class="info">
+        <span class="host"></span>
+        <span class="note"></span>
+        <span class="meta"></span>
+      </div>
+      <input type="button" class="remove" value="✕" data-i18n="popup_remove" data-i18n-value="title">
+    </div>
+  </template>
+  <script src="/utils.js"></script>
+  <script src="index.js"></script>
+</body>
+</html>

--- a/v3/data/popup/index.js
+++ b/v3/data/popup/index.js
@@ -1,0 +1,200 @@
+/* global getRelativeTime */
+'use strict';
+
+const $ = id => document.getElementById(id);
+
+// localization
+[...document.querySelectorAll('[data-i18n]')].forEach(e => {
+  e[e.dataset.i18nValue || 'textContent'] = chrome.i18n.getMessage(e.dataset.i18n);
+});
+
+const send = o => new Promise(resolve => chrome.runtime.sendMessage(o, resolve));
+
+let currentTab = null;
+let currentMatches = []; // blocked rules whose pattern matches the current URL
+
+// when the current tab is our own blocked page, act on the site it stands for
+const BLOCKED_BASE = chrome.runtime.getURL('/data/blocked/');
+const effective = () => {
+  const u = (currentTab && currentTab.url) || '';
+  if (u.startsWith(BLOCKED_BASE)) {
+    const orig = u.split('&url=')[1]; // the blocked page carries the raw address
+    if (orig) {
+      return {url: orig, onBlockedPage: true};
+    }
+  }
+  return {url: u, onBlockedPage: false};
+};
+
+// which blocked rules apply to a url
+const computeMatches = async (blocked, url) => {
+  if (!url || /^https?:/.test(url) === false || blocked.length === 0) {
+    return [];
+  }
+  const rules = await send({method: 'convert', hosts: blocked});
+  return blocked.filter((h, i) => {
+    try {
+      return new RegExp(rules[i].expression, 'i').test(url);
+    }
+    catch (e) {
+      return false;
+    }
+  });
+};
+
+// a blocking rule for a url's path (on the homepage the path is "/" -> whole site)
+const ruleForUrl = url => {
+  try {
+    const u = new URL(url);
+    return '*://' + u.hostname + u.pathname + '*';
+  }
+  catch (e) {
+    return '';
+  }
+};
+
+// block the current URL straight away; the tab is reloaded onto the blocked page
+const blockCurrent = () => {
+  const host = ruleForUrl(effective().url);
+  if (!host) {
+    return;
+  }
+  chrome.runtime.sendMessage({method: 'block-host', host, tabId: currentTab.id}, () => window.close());
+};
+
+// permanently unblock the current URL (remove its rule[s])
+const unblockCurrent = async () => {
+  if (currentMatches.length === 0) {
+    return;
+  }
+  const {onBlockedPage} = effective();
+  const ok = await send({method: 'remove-hosts', hosts: currentMatches});
+  if (!ok) {
+    return;
+  }
+  if (onBlockedPage) {
+    // the worker's update() sends the blocked page back to the now-allowed site
+    window.close();
+  }
+  else {
+    render(); // flip the button back to "Block this URL"
+  }
+};
+
+const removeHosts = async hosts => {
+  const ok = await send({method: 'remove-hosts', hosts});
+  if (ok) {
+    render();
+  }
+};
+
+const updateToggle = prefs => {
+  const btn = $('toggle');
+  const {url} = effective();
+  const usable = /^https?:/.test(url || '');
+  let host = null;
+  try {
+    host = usable ? new URL(url).hostname : null;
+  }
+  catch (e) {}
+
+  $('host').textContent = host || chrome.i18n.getMessage('popup_no_site');
+  btn.disabled = !usable;
+  btn.title = '';
+  btn.classList.remove('block');
+  if (!usable) {
+    btn.value = chrome.i18n.getMessage('popup_block');
+    return;
+  }
+  if (prefs.reverse) {
+    if (currentMatches.length) {
+      // explicitly allowed in reverse mode; the action removes that allow entry
+      btn.value = chrome.i18n.getMessage('popup_block');
+      btn.onclick = blockCurrent;
+      btn.classList.add('block');
+    }
+    else {
+      // blocked-by-default in reverse mode: adding an allow rule happens on the
+      // blocked page ("Add to Whitelist"); don't offer a no-op button
+      btn.value = chrome.i18n.getMessage('popup_toggle');
+      btn.onclick = null;
+      btn.disabled = true;
+      btn.title = chrome.i18n.getMessage('popup_reverse_hint');
+    }
+  }
+  else if (currentMatches.length) {
+    btn.value = chrome.i18n.getMessage('popup_unblock');
+    btn.onclick = unblockCurrent;
+  }
+  else {
+    btn.value = chrome.i18n.getMessage('popup_block');
+    btn.onclick = blockCurrent;
+    btn.classList.add('block');
+  }
+};
+
+const render = async () => {
+  const prefs = await chrome.storage.local.get({blocked: [], notes: {}, reverse: false});
+  // recompute on every render so the toggle flips right after a block/unblock
+  currentMatches = await computeMatches(prefs.blocked, effective().url);
+  updateToggle(prefs);
+
+  const filter = $('filter').value.trim().toLowerCase();
+  const hosts = prefs.blocked
+    .filter(h => h)
+    .filter(h => !filter || h.toLowerCase().includes(filter) ||
+      (prefs.notes[h]?.note || '').toLowerCase().includes(filter))
+    .sort((a, b) => (prefs.notes[b]?.date || 0) - (prefs.notes[a]?.date || 0));
+
+  const list = $('list');
+  list.textContent = '';
+  const tmpl = $('row');
+  for (const h of hosts) {
+    const node = document.importNode(tmpl.content, true);
+    node.querySelector('.host').textContent = h;
+
+    const note = prefs.notes[h]?.note;
+    const noteEl = node.querySelector('.note');
+    if (note) {
+      noteEl.textContent = note;
+      noteEl.title = note;
+    }
+    else {
+      noteEl.remove();
+    }
+
+    const parts = [];
+    const count = prefs.notes[h]?.count;
+    if (count) {
+      parts.push(chrome.i18n.getMessage('popup_blocked_count').replace('##', count));
+    }
+    const date = prefs.notes[h]?.date;
+    if (date) {
+      parts.push(getRelativeTime(new Date(date)));
+    }
+    node.querySelector('.meta').textContent = parts.join(' · ');
+
+    node.querySelector('.remove').addEventListener('click', () => removeHosts([h]));
+    list.appendChild(node);
+  }
+  $('empty').hidden = hosts.length > 0;
+};
+
+$('filter').addEventListener('input', render);
+$('options').addEventListener('click', e => {
+  e.preventDefault();
+  chrome.runtime.openOptionsPage();
+  window.close();
+});
+
+// keep the list fresh if rules change while the popup is open
+chrome.storage.onChanged.addListener(ps => {
+  if (ps.blocked || ps.notes) {
+    render();
+  }
+});
+
+chrome.tabs.query({active: true, currentWindow: true}, tabs => {
+  currentTab = tabs && tabs[0];
+  render();
+});

--- a/v3/manifest-firefox.json
+++ b/v3/manifest-firefox.json
@@ -40,7 +40,9 @@
     "256": "data/icons/256.png"
   },
   "homepage_url": "https://webextension.org/listing/block-site.html",
-  "action": {},
+  "action": {
+    "default_popup": "data/popup/index.html"
+  },
   "options_ui": {
     "page": "data/options/index.html",
     "open_in_tab": true

--- a/v3/manifest.json
+++ b/v3/manifest.json
@@ -31,7 +31,9 @@
     "256": "data/icons/256.png"
   },
   "homepage_url": "https://webextension.org/listing/block-site.html",
-  "action": {},
+  "action": {
+    "default_popup": "data/popup/index.html"
+  },
   "options_ui": {
     "page": "data/options/index.html",
     "open_in_tab": true

--- a/v3/worker.js
+++ b/v3/worker.js
@@ -272,6 +272,95 @@ chrome.runtime.onMessage.addListener((request, sender, response) => {
 
     return true;
   }
+  else if (request.method === 'block-host') {
+    // block a site straight from the popup: add it and let update() reload the
+    // tab onto the blocked page immediately (no domain-confirmation prompt),
+    // honoring the master password unless the user opted out
+    chrome.storage.local.get({
+      'blocked': [],
+      'notes': {},
+      'no-password-on-add': false,
+      'sha256': '',
+      'password': ''
+    }).then(prefs => {
+      const host = (request.host || '').trim();
+      if (!host) {
+        response(false);
+        return;
+      }
+      const doAdd = () => {
+        if (prefs.blocked.includes(host) === false) {
+          prefs.blocked.push(host);
+          prefs.notes[host] = {date: Date.now(), origin: 'popup', count: 0};
+        }
+        chrome.storage.local.set({
+          blocked: prefs.blocked,
+          notes: prefs.notes,
+          changed: Math.random() // make sure the blocker reloads matching tabs
+        }, () => response(true));
+      };
+      if ((prefs.password || prefs.sha256) && prefs['no-password-on-add'] === false) {
+        prompt(translate('bg_msg_17')).then(password => {
+          if (password) {
+            sha256.validate({password}, doAdd, msg => {
+              response(false);
+              notify(msg || translate('bg_msg_2'));
+            });
+          }
+          else {
+            response(false);
+          }
+        });
+      }
+      else {
+        doAdd();
+      }
+    });
+
+    return true;
+  }
+  else if (request.method === 'remove-hosts') {
+    // remove one or more blocked hostnames from the popup, honoring the
+    // master password unless the user opted out for adding/removing rules
+    chrome.storage.local.get({
+      'blocked': [],
+      'notes': {},
+      'no-password-on-add': false,
+      'sha256': '',
+      'password': ''
+    }).then(prefs => {
+      const doRemove = () => {
+        const drop = new Set(request.hosts);
+        const blocked = prefs.blocked.filter(h => drop.has(h) === false);
+        for (const h of request.hosts) {
+          delete prefs.notes[h];
+        }
+        chrome.storage.local.set({
+          blocked,
+          notes: prefs.notes,
+          changed: Math.random() // make sure the blocker reloads
+        }, () => response(true));
+      };
+      if ((prefs.password || prefs.sha256) && prefs['no-password-on-add'] === false) {
+        prompt(translate('bg_msg_17')).then(password => {
+          if (password) {
+            sha256.validate({password}, doRemove, msg => {
+              response(false);
+              notify(msg || translate('bg_msg_2'));
+            });
+          }
+          else {
+            response(false);
+          }
+        });
+      }
+      else {
+        doRemove();
+      }
+    });
+
+    return true;
+  }
   else if (request.method === 'close-page') {
     if (sender.frameId === 0) {
       chrome.tabs.remove(sender.tab.id);
@@ -285,6 +374,21 @@ chrome.alarms.onAlarm.addListener(alarm => {
     chrome.declarativeNetRequest.updateDynamicRules({
       removeRuleIds: [998]
     });
+  }
+});
+
+/* toolbar popup: show the blocked-sites overview, or fall back to the
+   one-click "block current site" action when the popup is disabled */
+const applyPopup = () => chrome.storage.local.get({popup: true}, prefs => {
+  chrome.action.setPopup({
+    popup: prefs.popup ? '/data/popup/index.html' : ''
+  });
+});
+chrome.runtime.onStartup.addListener(applyPopup);
+chrome.runtime.onInstalled.addListener(applyPopup);
+chrome.storage.onChanged.addListener(ps => {
+  if (ps.popup) {
+    applyPopup();
   }
 });
 

--- a/v3/worker.js
+++ b/v3/worker.js
@@ -503,8 +503,17 @@ const applyPopup = () => chrome.storage.local.get({popup: true}, prefs => {
     popup: prefs.popup ? '/data/popup/index.html' : ''
   });
 });
-chrome.runtime.onStartup.addListener(applyPopup);
-chrome.runtime.onInstalled.addListener(applyPopup);
+{
+  const once = () => {
+    if (once.done) {
+      return;
+    }
+    once.done = true;
+    applyPopup();
+  };
+  chrome.runtime.onStartup.addListener(once);
+  chrome.runtime.onInstalled.addListener(once);
+}
 chrome.storage.onChanged.addListener(ps => {
   if (ps.popup) {
     applyPopup();


### PR DESCRIPTION
Split out of #172 as requested — this part only adds the toolbar overview popup.

Clicking the toolbar icon now opens an overview (asked for in #40, and it shows the whole domain list at a glance, refs #5): every blocking rule with its metadata (blocked count, relative date), filterable, each removable, plus a button that blocks or unblocks the URL of the active tab.

- **“Block this URL”** blocks the current address (`*://host/path*`; on the homepage this covers the whole site) immediately — the open tab reloads onto the blocked page right away, honoring the master password unless `no-password-on-add` is set. The button flips to **“Unblock this URL”** live after the rules change.
- On the blocked page itself the popup acts on the site the page stands in for, so a fresh block can be undone with one click.
- The rule that caught a page is editable on the blocked page, so its scope can be narrowed to a path or widened to the whole site; the rule’s metadata follows the rename.
- A new option restores the previous icon behavior (one-click block of the current site) via `chrome.action.setPopup`; in reverse mode the toggle explains that allowing happens through “Add to Whitelist”.

### Testing
- Node unit suite over a `chrome.*` mock: `setPopup` wiring on startup/pref change, `block-host` (direct add + reload trigger, password prompt honored, empty host refused) and `remove-hosts` (notes cleaned up, password honored) — 9/9 pass.
- End-to-end on real Chrome for Testing: popup “Block this URL” ⇒ site stored, no confirmation window, the already-open tab lands on the blocked page immediately. Popup flows also exercised on Firefox 152.
- `web-ext lint`: 0 errors; en+de locales included; `action.default_popup`/`setPopup` exist on Chrome, Edge, Opera and Firefox ≥ 116 (manifest floor is 128).

Closes #40 (refs #5).

Independent of the other split PRs: with the per-site notes PR (#175) merged, each row also shows the site’s note in small text — the popup already renders it if present, so no follow-up change is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)