### PR TITLE
Drop the Chromium-only storage.managed_schema key from the Firefox manifest

### DIFF
--- a/v3/manifest-firefox.json
+++ b/v3/manifest-firefox.json
@@ -28,9 +28,6 @@
   "host_permissions": [
     "<all_urls>"
   ],
-  "storage": {
-    "managed_schema": "schema.json"
-  },
   "icons": {
     "16": "data/icons/16.png",
     "32": "data/icons/32.png",


### PR DESCRIPTION
Split out of #172 as requested — smallest piece.

Firefox does not support the `storage` manifest key and warns on every load:

> Reading manifest: Warning processing storage: An unexpected property was found in the WebExtension manifest.

Firefox reads managed storage from native manifests instead, so the key has no effect there; `manifest.json` (Chromium) keeps it. `web-ext lint`: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)